### PR TITLE
feat(observatory): add Traefik forwardAuth middleware for JWT validation

### DIFF
--- a/apps/observatory/traefik-middleware-auth.yaml
+++ b/apps/observatory/traefik-middleware-auth.yaml
@@ -1,0 +1,12 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: observatory-auth
+  namespace: observatory
+spec:
+  forwardAuth:
+    # Calls auth-svc introspect internally — never leaves the cluster
+    address: http://auth-svc.observatory.svc.cluster.local:8081/auth/introspect
+    authResponseHeaders:
+      - X-User-Subject   # verified subject (user ID) forwarded to upstream
+      - X-User-Email     # verified email forwarded to upstream


### PR DESCRIPTION
## Summary
- Adds `apps/observatory/traefik-middleware-auth.yaml` — Traefik `forwardAuth` middleware
- Replaces the planned `observatory-api-gateway` custom service
- Traefik delegates JWT validation to `auth-svc /auth/introspect` internally
- Injects `X-User-Subject` and `X-User-Email` headers for downstream services

## How it works
All protected routes (user-svc, alert-svc, incident-svc) reference this middleware via annotation:
```
traefik.ingress.kubernetes.io/router.middlewares: observatory-observatory-auth@kubernetescrd
```

## Auto-applied by ArgoCD
The `observatory-auth-svc-config` Application already syncs `apps/observatory/` — no new ArgoCD Application needed.

## Test plan
- [ ] Merge and verify ArgoCD syncs the Middleware CRD
- [ ] Verify middleware is visible: `kubectl get middleware -n observatory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)